### PR TITLE
refactor: move Money from Entities to ValueObjects

### DIFF
--- a/BidCalculation.Domain/ValueObjects/Money.cs
+++ b/BidCalculation.Domain/ValueObjects/Money.cs
@@ -1,6 +1,6 @@
 ﻿using BidCalculation.Domain.Core;
 
-namespace BidCalculation.Domain.Entities;
+namespace BidCalculation.Domain.ValueObjects;
 
 public class Money : Entity
 {


### PR DESCRIPTION
### Description:

**Refactor:** Moved `Money` from `Entities` to `ValueObjects`.

This merge refactors the domain structure to align with **Domain-Driven Design (DDD)** principles. The `Money` class, previously located in the `Entities` folder, has been moved to the `ValueObjects` folder, as it represents an immutable value concept, making it more suitable as a **Value Object**. This change enhances clarity and maintains a better separation between **Entities** and **Value Objects**.

#### Changes:
- Moved `Money` from **`Entities`** to **`ValueObjects`**.
- No logic was changed; functionality remains intact.
- Updated references to the `Money` class to reflect its new location.

This refactor improves code maintainability and clarity, following best practices in DDD and object-oriented design.
